### PR TITLE
Fix cloud building

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,12 +30,6 @@
             <artifactId>dropbox-core-sdk</artifactId>
             <version>3.0.4</version>
         </dependency>
-        <dependency>
-            <groupId>tc.oc</groupId>
-            <artifactId>test-util</artifactId>
-            <version>1.0-SNAPSHOT</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
This dependency appears unused.

Its presence is preventing the project from building successfully, since the repository where it is located seems to have a bad certificate

It builds successfully when running `docker build -t dropbox .` with this dependency removed